### PR TITLE
Issue#18: error thrown with missing constant

### DIFF
--- a/printgrantpdfs.php
+++ b/printgrantpdfs.php
@@ -113,7 +113,7 @@ function printgrantpdfs_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 
 function printgrantpdfs_civicrm_searchTasks($objectType, &$tasks) {
   if ($objectType == 'grant') {
-    $tasks[CRM_Grant_Task::PRINT_GRANTS] = array(
+    $tasks[CRM_Grant_Task::TASK_PRINT] = array(
       'title' => ts('Print Grants as PDF'),
       'class' => 'CRM_Grant_Form_Task_PrintPDF',
       'result' => FALSE,


### PR DESCRIPTION
This is a regression caused by https://github.com/civicrm/civicrm-core/commit/7b9bce60ad124d0867bab01f27aadf8f4f7fb74d changes in core, where CRM_Grant_Task::PRINT_GRANTS were changed to CRM_Grant_Task::TASK_PRINT. The current patch corrects the constant name.